### PR TITLE
fix(bugs #10-#18): deployment-critical fixes from live testing

### DIFF
--- a/crates/agent/src/bootstrap/mod.rs
+++ b/crates/agent/src/bootstrap/mod.rs
@@ -10,6 +10,8 @@ pub use negotiator::NegotiateError;
 
 const DEFAULT_CONFIG_DIR: &str = "/etc/sentinel";
 const CONFIG_FILE_NAME: &str = "config.yml";
+const MAX_BOOTSTRAP_RETRIES: u32 = 5;
+const BASE_BACKOFF_SECS: u64 = 5;
 
 pub async fn run_if_needed(
     config_path: &Path,
@@ -36,26 +38,59 @@ pub async fn run_if_needed(
 
     let hw_id = sysinfo::System::host_name().unwrap_or_else(|| "unknown-hw".into());
 
-    tracing::info!(target: "boot", server = %server_url, hw_id = %hw_id, "Negotiating bootstrap");
+    let mut last_err = None;
+    for attempt in 1..=MAX_BOOTSTRAP_RETRIES {
+        tracing::info!(
+            target: "boot",
+            server = %server_url,
+            hw_id = %hw_id,
+            attempt,
+            max = MAX_BOOTSTRAP_RETRIES,
+            "Negotiating bootstrap"
+        );
 
-    let result = negotiator::negotiate(&server_url, &token, &hw_id).await?;
+        match negotiator::negotiate(&server_url, &token, &hw_id).await {
+            Ok(result) => {
+                tracing::info!(
+                    target: "boot",
+                    agent_id = %result.agent_id,
+                    "Bootstrap successful, writing config"
+                );
 
-    tracing::info!(
-        target: "boot",
-        agent_id = %result.agent_id,
-        "Bootstrap successful, writing config"
-    );
+                let config_dir = config_path
+                    .parent()
+                    .unwrap_or_else(|| Path::new(DEFAULT_CONFIG_DIR));
 
-    let config_dir = config_path
-        .parent()
-        .unwrap_or_else(|| Path::new(DEFAULT_CONFIG_DIR));
+                config_writer::write_config(config_dir, &result.config_yaml)?;
+                cleanup::scrub_token_from_env();
 
-    config_writer::write_config(config_dir, &result.config_yaml)?;
+                let written_path = config_dir.join(CONFIG_FILE_NAME);
+                tracing::info!(
+                    target: "boot",
+                    path = %written_path.display(),
+                    "Agent provisioned, reloading config"
+                );
 
-    cleanup::scrub_token_from_env();
+                return Ok(Some(written_path));
+            }
+            Err(e) => {
+                let delay = BASE_BACKOFF_SECS * 2u64.pow(attempt - 1);
+                tracing::warn!(
+                    target: "boot",
+                    error = %e,
+                    attempt,
+                    retry_in_secs = delay,
+                    "Bootstrap attempt failed"
+                );
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+            }
+        }
+    }
 
-    let written_path = config_dir.join(CONFIG_FILE_NAME);
-    tracing::info!(target: "boot", path = %written_path.display(), "Agent provisioned, reloading config");
-
-    Ok(Some(written_path))
+    Err(format!(
+        "Bootstrap failed after {MAX_BOOTSTRAP_RETRIES} attempts: {}",
+        last_err.map(|e| e.to_string()).unwrap_or_default()
+    )
+    .into())
 }

--- a/crates/cli/src/cmd/agents/add.rs
+++ b/crates/cli/src/cmd/agents/add.rs
@@ -64,7 +64,9 @@ async fn deploy_docker_agent(name: &str, token: &str, mode: OutputMode) -> Resul
     let container_name = format!("sentinel-{name}");
 
     let cfg = crate::store::load().unwrap_or_default();
-    let grpc_url = &cfg.server.grpc_url;
+    let server_url = &cfg.server.grpc_url;
+
+    cleanup_existing_container(&container_name).await;
 
     let sp = spinner::create(&format!("Deploying container '{container_name}'..."));
 
@@ -75,9 +77,13 @@ async fn deploy_docker_agent(name: &str, token: &str, mode: OutputMode) -> Resul
             "--name",
             &container_name,
             "-e",
-            &format!("SENTINEL_TOKEN={token}"),
+            &format!("BOOTSTRAP_TOKEN={token}"),
             "-e",
-            &format!("SENTINEL_GRPC_URL={grpc_url}"),
+            &format!("SERVER_URL={server_url}"),
+            "-v",
+            &format!("{container_name}-config:/etc/sentinel"),
+            "--network",
+            "sentinel-net",
             "--restart",
             "unless-stopped",
             "sentinelrs/agent:latest",
@@ -91,7 +97,7 @@ async fn deploy_docker_agent(name: &str, token: &str, mode: OutputMode) -> Resul
         Ok(s) if s.success() => {
             spinner::finish_ok(&sp, &format!("Agent '{name}' deployed"));
             if mode == OutputMode::Human {
-                wait_for_agent(name).await;
+                wait_for_agent(name, &container_name).await;
             }
         }
         _ => {
@@ -103,8 +109,34 @@ async fn deploy_docker_agent(name: &str, token: &str, mode: OutputMode) -> Resul
     Ok(())
 }
 
-async fn wait_for_agent(name: &str) {
+async fn cleanup_existing_container(container_name: &str) {
+    let _ = tokio::process::Command::new("docker")
+        .args(["rm", "-f", container_name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await;
+}
+
+async fn wait_for_agent(name: &str, container_name: &str) {
     let sp = spinner::create("Waiting for agent bootstrap...");
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    spinner::finish_ok(&sp, &format!("Agent '{name}' is ONLINE"));
+
+    for _ in 0..10 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        let output = tokio::process::Command::new("docker")
+            .args(["inspect", "-f", "{{.State.Running}}", container_name])
+            .output()
+            .await;
+
+        match output {
+            Ok(o) if String::from_utf8_lossy(&o.stdout).trim() == "true" => {
+                spinner::finish_ok(&sp, &format!("Agent '{name}' is running"));
+                return;
+            }
+            _ => continue,
+        }
+    }
+
+    spinner::finish_err(&sp, &format!("Agent '{name}' did not start in time"));
 }

--- a/crates/server/src/migration/loader.rs
+++ b/crates/server/src/migration/loader.rs
@@ -77,5 +77,9 @@ pub fn load_all() -> Vec<MigrationFile> {
             filename: "017_metrics_5m_aggregate.sql",
             sql: include_str!("../../../../migrations/017_metrics_5m_aggregate.sql"),
         },
+        MigrationFile {
+            filename: "018_compatibility_views.sql",
+            sql: include_str!("../../../../migrations/018_compatibility_views.sql"),
+        },
     ]
 }

--- a/crates/workers/src/aggregator/store.rs
+++ b/crates/workers/src/aggregator/store.rs
@@ -64,6 +64,14 @@ impl AggregatorStore {
         };
         self.series.get(&key).and_then(|s| s.last())
     }
+
+    pub fn count(&self, agent_id: &str, name: &str) -> usize {
+        let key = MetricKey {
+            agent_id: agent_id.to_string(),
+            name: name.to_string(),
+        };
+        self.series.get(&key).map(|s| s.count()).unwrap_or(0)
+    }
 }
 
 #[cfg(test)]

--- a/crates/workers/src/alert/evaluator.rs
+++ b/crates/workers/src/alert/evaluator.rs
@@ -12,6 +12,8 @@ pub struct Evaluator {
     states: Arc<DashMap<String, RuleState>>,
 }
 
+const MIN_SAMPLES: usize = 2;
+
 impl Evaluator {
     pub fn new(rules: Vec<Rule>) -> Self {
         Self {
@@ -47,6 +49,10 @@ impl Evaluator {
             }
 
             let fp = fingerprint_string(&rule.id, agent_id, &rule.metric_name);
+
+            if aggregator.count(agent_id, &rule.metric_name) < MIN_SAMPLES {
+                continue;
+            }
 
             let value = match aggregator.avg(agent_id, &rule.metric_name) {
                 Some(v) => v,
@@ -134,6 +140,7 @@ mod tests {
     #[test]
     fn fires_when_threshold_exceeded() {
         let agg = AggregatorStore::new(10000);
+        agg.ingest("agent-1", "cpu", 500, 90.0);
         agg.ingest("agent-1", "cpu", 1000, 90.0);
 
         let eval = Evaluator::new(vec![cpu_rule()]);
@@ -145,6 +152,7 @@ mod tests {
     #[test]
     fn no_event_below_threshold() {
         let agg = AggregatorStore::new(10000);
+        agg.ingest("agent-1", "cpu", 500, 50.0);
         agg.ingest("agent-1", "cpu", 1000, 50.0);
 
         let eval = Evaluator::new(vec![cpu_rule()]);
@@ -155,6 +163,7 @@ mod tests {
     #[test]
     fn fires_only_once() {
         let agg = AggregatorStore::new(10000);
+        agg.ingest("agent-1", "cpu", 500, 90.0);
         agg.ingest("agent-1", "cpu", 1000, 90.0);
 
         let eval = Evaluator::new(vec![cpu_rule()]);
@@ -169,6 +178,7 @@ mod tests {
     #[test]
     fn resolves_when_back_below() {
         let agg = AggregatorStore::new(10000);
+        agg.ingest("agent-1", "cpu", 500, 90.0);
         agg.ingest("agent-1", "cpu", 1000, 90.0);
 
         let eval = Evaluator::new(vec![cpu_rule()]);
@@ -197,7 +207,8 @@ mod tests {
         let mut rule = cpu_rule();
         rule.for_duration_ms = 5000;
 
-        let agg = AggregatorStore::new(10000);
+        let agg = AggregatorStore::new(20000);
+        agg.ingest("a", "cpu", 500, 90.0);
         agg.ingest("a", "cpu", 1000, 90.0);
 
         let eval = Evaluator::new(vec![rule]);

--- a/crates/workers/src/alert/test_harness.rs
+++ b/crates/workers/src/alert/test_harness.rs
@@ -103,6 +103,12 @@ mod tests {
             MetricSample {
                 agent_id: "a1".into(),
                 metric_name: "cpu".into(),
+                timestamp_ms: 500,
+                value: 90.0,
+            },
+            MetricSample {
+                agent_id: "a1".into(),
+                metric_name: "cpu".into(),
                 timestamp_ms: 1000,
                 value: 90.0,
             },
@@ -148,6 +154,12 @@ mod tests {
             MetricSample {
                 agent_id: "a1".into(),
                 metric_name: "cpu".into(),
+                timestamp_ms: 500,
+                value: 90.0,
+            },
+            MetricSample {
+                agent_id: "a1".into(),
+                metric_name: "cpu".into(),
                 timestamp_ms: 1000,
                 value: 90.0,
             },
@@ -162,6 +174,12 @@ mod tests {
         assert_eq!(result.firing_count, 0);
 
         let samples_long = vec![
+            MetricSample {
+                agent_id: "a1".into(),
+                metric_name: "cpu".into(),
+                timestamp_ms: 500,
+                value: 90.0,
+            },
             MetricSample {
                 agent_id: "a1".into(),
                 metric_name: "cpu".into(),
@@ -182,6 +200,18 @@ mod tests {
     #[test]
     fn multi_agent_independent() {
         let samples = vec![
+            MetricSample {
+                agent_id: "a1".into(),
+                metric_name: "cpu".into(),
+                timestamp_ms: 500,
+                value: 90.0,
+            },
+            MetricSample {
+                agent_id: "a2".into(),
+                metric_name: "cpu".into(),
+                timestamp_ms: 500,
+                value: 90.0,
+            },
             MetricSample {
                 agent_id: "a1".into(),
                 metric_name: "cpu".into(),
@@ -215,6 +245,18 @@ mod tests {
         };
 
         let samples = vec![
+            MetricSample {
+                agent_id: "a1".into(),
+                metric_name: "cpu".into(),
+                timestamp_ms: 500,
+                value: 90.0,
+            },
+            MetricSample {
+                agent_id: "a1".into(),
+                metric_name: "memory".into(),
+                timestamp_ms: 500,
+                value: 95.0,
+            },
             MetricSample {
                 agent_id: "a1".into(),
                 metric_name: "cpu".into(),

--- a/crates/workers/src/storage/agent_repo.rs
+++ b/crates/workers/src/storage/agent_repo.rs
@@ -10,7 +10,7 @@ impl AgentRepo {
     }
 
     pub async fn touch_last_seen(&self, agent_id: &str) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE agents SET last_seen = NOW() WHERE agent_id = $1")
+        sqlx::query("UPDATE agents SET last_seen = NOW(), status = 'online' WHERE agent_id = $1")
             .bind(agent_id)
             .execute(&self.pool)
             .await?;

--- a/crates/workers/tests/pipeline_integration.rs
+++ b/crates/workers/tests/pipeline_integration.rs
@@ -78,6 +78,7 @@ async fn full_pipeline_verify_dedup_transform_alert() {
     for row in &rows {
         if let Some(v) = row.value {
             aggregator.ingest(&row.agent_id, &row.name, row.time_ms, v);
+            aggregator.ingest(&row.agent_id, &row.name, row.time_ms + 1000, v);
         }
     }
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -114,6 +114,7 @@ services:
             sentinel-server:
                 condition: service_healthy
         environment:
+            BOOTSTRAP_TOKEN: ${BOOTSTRAP_TOKEN:-}
             SERVER_URL: ${SERVER_URL:-http://sentinel-server:50051}
             RUST_LOG: ${AGENT_LOG_LEVEL:-info}
             AGENT_COLLECT_INTERVAL: ${AGENT_COLLECT_INTERVAL:-10}

--- a/migrations/018_compatibility_views.sql
+++ b/migrations/018_compatibility_views.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW metrics AS
+SELECT * FROM metrics_time;
+
+CREATE OR REPLACE VIEW v_agents AS
+SELECT
+    agent_id AS id,
+    agent_id,
+    name,
+    status,
+    labels,
+    last_seen,
+    created_at
+FROM agents;


### PR DESCRIPTION
- #10: CLI agents add --docker passes correct env vars (BOOTSTRAP_TOKEN, SERVER_URL)
- #11: wait_for_agent now polls docker inspect instead of blind sleep+print
- #12/#17: agent_repo.touch_last_seen also sets status='online'
- #13: alert evaluator requires MIN_SAMPLES(2) before evaluation
- #14: cleanup existing container before docker run (no more zombies)
- #15: docker-compose agent service now includes BOOTSTRAP_TOKEN env var
- #16: migration 018 adds compatibility views (metrics, v_agents)
- #18: bootstrap retries with exponential backoff (5 attempts)