### PR TITLE
fix(migration-018): align v_agents view with actual agents schema

### DIFF
--- a/migrations/018_compatibility_views.sql
+++ b/migrations/018_compatibility_views.sql
@@ -5,9 +5,9 @@ CREATE OR REPLACE VIEW v_agents AS
 SELECT
     agent_id AS id,
     agent_id,
-    name,
+    hw_id,
     status,
-    labels,
+    agent_version,
     last_seen,
-    created_at
+    to_timestamp(registered_at_ms / 1000.0) AS registered_at
 FROM agents;


### PR DESCRIPTION
The view referenced non-existent columns (name, labels, created_at). Mapped to real V2 columns: hw_id, agent_version, registered_at_ms.